### PR TITLE
IP Proto - u8

### DIFF
--- a/src/calc.rs
+++ b/src/calc.rs
@@ -12,10 +12,10 @@ pub fn calculate_community_id(
     dst_ip: IpAddr,
     src_port: Option<u16>,
     dst_port: Option<u16>,
-    ip_proto: i32,
+    ip_proto: u8,
     disable_base64: bool,
 ) -> Result<String> {
-    match ip_proto {
+    match ip_proto as i32 {
         IPPROTO_ICMP | IPPROTO_ICMPV6 | IPPROTO_TCP | IPPROTO_UDP | IPPROTO_SCTP => {
             if src_port.is_none() || dst_port.is_none() {
                 return Err(anyhow!(
@@ -67,5 +67,20 @@ mod tests {
             Default::default(),
         );
         assert_eq!("1:wCb3OG7yAFWelaUydu0D+125CLM=", id.unwrap());
+    }
+
+    #[test]
+    fn test_tcp_without_ports() {
+        let id = calculate_community_id(
+            0,
+            Ipv4Addr::new(1, 2, 3, 4).into(),
+            Ipv4Addr::new(5, 6, 7, 8).into(),
+            None,
+            None,
+            6,
+            Default::default(),
+        );
+        assert!(id.is_err());
+        assert_eq!("src port and dst port should be set when protocol is icmp/icmp6/tcp/udp/sctp", id.err().unwrap().to_string());
     }
 }

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -14,7 +14,7 @@ pub fn calculate_ipv4_community_id(
     dst_ip: Ipv4Addr,
     src_port: Option<u16>,
     dst_port: Option<u16>,
-    ip_proto: i32,
+    ip_proto: u8,
     disable_base64: bool,
 ) -> Result<String> {
     let mut sip = <Ipv4Addr as Into<u32>>::into(src_ip).to_be();
@@ -28,7 +28,7 @@ pub fn calculate_ipv4_community_id(
     if src_port.is_some() && dst_port.is_some() {
         let tmp_src_port = src_port.unwrap();
         let tmp_dst_port = dst_port.unwrap();
-        match ip_proto {
+        match ip_proto as i32 {
             IPPROTO_ICMP => {
                 let (src, dst, one_way) = icmpv4::get_port_equivalents(tmp_src_port, tmp_dst_port);
                 is_one_way = one_way;
@@ -50,7 +50,7 @@ pub fn calculate_ipv4_community_id(
             seed: seed.to_be(),
             src_ip: sip,
             dst_ip: dip,
-            proto: ip_proto as u8,
+            proto: ip_proto,
             pad0: PADDING,
             src_port: sport.unwrap(),
             dst_port: dport.unwrap(),
@@ -61,7 +61,7 @@ pub fn calculate_ipv4_community_id(
             seed: seed.to_be(),
             src_ip: sip,
             dst_ip: dip,
-            proto: ip_proto as u8,
+            proto: ip_proto,
             pad0: PADDING,
         };
         Sha1::new().chain(ipv4).finalize()

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -14,7 +14,7 @@ pub fn calculate_ipv6_community_id(
     dst_ip: Ipv6Addr,
     src_port: Option<u16>,
     dst_port: Option<u16>,
-    ip_proto: i32,
+    ip_proto: u8,
     disable_base64: bool,
 ) -> Result<String> {
     let mut sip = src_ip.octets();
@@ -28,7 +28,7 @@ pub fn calculate_ipv6_community_id(
     if src_port.is_some() && dst_port.is_some() {
         let tmp_src_port = src_port.unwrap();
         let tmp_dst_port = dst_port.unwrap();
-        match ip_proto {
+        match ip_proto as i32 {
             IPPROTO_ICMPV6 => {
                 let (src, dst, one_way) = icmpv6::get_port_equivalents(tmp_src_port, tmp_dst_port);
                 is_one_way = one_way;
@@ -50,7 +50,7 @@ pub fn calculate_ipv6_community_id(
             seed: seed.to_be(),
             src_ip: sip,
             dst_ip: dip,
-            proto: ip_proto as u8,
+            proto: ip_proto,
             pad0: PADDING,
             src_port: sport.unwrap(),
             dst_port: dport.unwrap(),
@@ -61,7 +61,7 @@ pub fn calculate_ipv6_community_id(
             seed: seed.to_be(),
             src_ip: sip,
             dst_ip: dip,
-            proto: ip_proto as u8,
+            proto: ip_proto,
             pad0: PADDING,
         };
         Sha1::new().chain(ipv6).finalize()


### PR DESCRIPTION
Hello,

Thanks for this great package. I was wondering if you would be open to swapping the public API to use a `u8` instead of a `i32` for the `ip_proto` parameter. 

This matches the Community IDs specification of the IP Protocol being one byte. 

I have added a test to confirm that the cast to a `i32` for checking against the `libc` constants still functions as it previously was. 