### PR TITLE
Removed libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.71"
-libc = "0.2"
 lazy_static = "1.4.0"
 sha1 = "0.10.5"
 base64 = "0.21.0"

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -2,9 +2,7 @@ use std::net::IpAddr;
 
 use anyhow::{anyhow, Result};
 
-use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_SCTP, IPPROTO_TCP, IPPROTO_UDP};
-
-use crate::{ipv4, ipv6};
+use crate::{ipv4, ipv6, IPPROTO_ICMP, IPPROTO_ICMPV6, IPPROTO_SCTP, IPPROTO_TCP, IPPROTO_UDP};
 
 pub fn calculate_community_id(
     seed: u16,
@@ -15,7 +13,7 @@ pub fn calculate_community_id(
     ip_proto: u8,
     disable_base64: bool,
 ) -> Result<String> {
-    match ip_proto as i32 {
+    match ip_proto {
         IPPROTO_ICMP | IPPROTO_ICMPV6 | IPPROTO_TCP | IPPROTO_UDP | IPPROTO_SCTP => {
             if src_port.is_none() || dst_port.is_none() {
                 return Err(anyhow!(

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -2,11 +2,10 @@ use std::net::Ipv4Addr;
 
 use anyhow::{anyhow, Result};
 use base64::prelude::*;
-use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6};
 use sha1::digest::Update;
 use sha1::{Digest, Sha1};
 
-use crate::{icmpv4, PADDING};
+use crate::{icmpv4, PADDING, IPPROTO_ICMP, IPPROTO_ICMPV6};
 
 pub fn calculate_ipv4_community_id(
     seed: u16,
@@ -28,7 +27,7 @@ pub fn calculate_ipv4_community_id(
     if src_port.is_some() && dst_port.is_some() {
         let tmp_src_port = src_port.unwrap();
         let tmp_dst_port = dst_port.unwrap();
-        match ip_proto as i32 {
+        match ip_proto {
             IPPROTO_ICMP => {
                 let (src, dst, one_way) = icmpv4::get_port_equivalents(tmp_src_port, tmp_dst_port);
                 is_one_way = one_way;

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -2,11 +2,10 @@ use std::net::Ipv6Addr;
 
 use anyhow::{anyhow, Result};
 use base64::prelude::*;
-use libc::{IPPROTO_ICMP, IPPROTO_ICMPV6};
 use sha1::digest::Update;
 use sha1::{Digest, Sha1};
 
-use crate::{icmpv6, PADDING};
+use crate::{icmpv6, PADDING, IPPROTO_ICMP,IPPROTO_ICMPV6};
 
 pub fn calculate_ipv6_community_id(
     seed: u16,
@@ -28,7 +27,7 @@ pub fn calculate_ipv6_community_id(
     if src_port.is_some() && dst_port.is_some() {
         let tmp_src_port = src_port.unwrap();
         let tmp_dst_port = dst_port.unwrap();
-        match ip_proto as i32 {
+        match ip_proto {
             IPPROTO_ICMPV6 => {
                 let (src, dst, one_way) = icmpv6::get_port_equivalents(tmp_src_port, tmp_dst_port);
                 is_one_way = one_way;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,10 @@ mod ipv4;
 mod ipv6;
 
 const PADDING: u8 = 0;
+const IPPROTO_ICMP: u8 = 1;
+const IPPROTO_ICMPV6: u8 = 58;
+const IPPROTO_SCTP: u8 = 132;
+const IPPROTO_TCP: u8 = 6;
+const IPPROTO_UDP: u8 = 17;
 
 pub use calc::calculate_community_id;


### PR DESCRIPTION
Hello,

This PR removes the use of `libc`, swapping the constants that were used from it for Rust constants. The reasoning behind wanting this change is to allow for this library to be used in environments that do not have `libc`, such as when compiling Rust to WASM.

An example of this, I am currently trying to add a community ID function using this libary to [VRL](https://github.com/vectordotdev/vrl), however that targets WASM as well as other platforms. 

