### PR TITLE
Add ICMP over IPv6 suppport

### DIFF
--- a/src/calc.rs
+++ b/src/calc.rs
@@ -23,10 +23,10 @@ pub fn calculate_community_id(
     disable_base64: bool,
 ) -> Result<String> {
     match ip_proto {
-        IPPROTO_ICMP | IPPROTO_ICMPV6 | IPPROTO_TCP | IPPROTO_UDP | IPPROTO_SCTP => {
+        IPPROTO_ICMPV6 | IPPROTO_TCP | IPPROTO_UDP | IPPROTO_SCTP => {
             if src_port.is_none() || dst_port.is_none() {
                 return Err(anyhow!(
-                    "src port and dst port should be set when protocol is icmp/icmp6/tcp/udp/sctp"
+                    "src port and dst port should be set when protocol is icmp6/tcp/udp/sctp"
                 ));
             }
         }
@@ -89,7 +89,7 @@ mod tests {
         );
         assert!(id.is_err());
         assert_eq!(
-            "src port and dst port should be set when protocol is icmp/icmp6/tcp/udp/sctp",
+            "src port and dst port should be set when protocol is icmp6/tcp/udp/sctp",
             id.err().unwrap().to_string()
         );
     }

--- a/src/calc.rs
+++ b/src/calc.rs
@@ -23,10 +23,10 @@ pub fn calculate_community_id(
     disable_base64: bool,
 ) -> Result<String> {
     match ip_proto {
-        IPPROTO_ICMPV6 | IPPROTO_TCP | IPPROTO_UDP | IPPROTO_SCTP => {
+        IPPROTO_TCP | IPPROTO_UDP | IPPROTO_SCTP => {
             if src_port.is_none() || dst_port.is_none() {
                 return Err(anyhow!(
-                    "src port and dst port should be set when protocol is icmp6/tcp/udp/sctp"
+                    "src port and dst port should be set when protocol is tcp/udp/sctp"
                 ));
             }
         }
@@ -89,7 +89,7 @@ mod tests {
         );
         assert!(id.is_err());
         assert_eq!(
-            "src port and dst port should be set when protocol is icmp6/tcp/udp/sctp",
+            "src port and dst port should be set when protocol is tcp/udp/sctp",
             id.err().unwrap().to_string()
         );
     }

--- a/src/icmpv4.rs
+++ b/src/icmpv4.rs
@@ -46,3 +46,40 @@ pub(crate) fn get_port_equivalents(mtype: u16, mcode: u16) -> (u16, u16, bool) {
         Err(_) => return (mtype, mcode, true),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use crate::calculate_community_id;
+
+    #[test]
+    fn test_icmp_with_ports() {
+        let id = calculate_community_id(
+            0,
+            Ipv4Addr::new(10, 10, 10, 10).into(),
+            Ipv4Addr::new(10, 10, 10, 10).into(),
+            Some(0),
+            Some(8),
+            1,
+            Default::default(),
+        );
+
+        assert_eq!("1:4MHSMLtBw+4q7Wke3ztBRVwtgt0=", id.unwrap());
+    }
+
+    #[test]
+    fn test_icmp_without_ports() {
+        let id = calculate_community_id(
+            0,
+            Ipv4Addr::new(10, 10, 10, 10).into(),
+            Ipv4Addr::new(10, 10, 10, 10).into(),
+            None,
+            None,
+            1,
+            Default::default(),
+        );
+
+        assert_eq!("1:4MHSMLtBw+4q7Wke3ztBRVwtgt0=", id.unwrap());
+    }
+}

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -5,7 +5,7 @@ use base64::prelude::*;
 use sha1::digest::Update;
 use sha1::{Digest, Sha1};
 
-use crate::{icmpv4, PADDING, IPPROTO_ICMP, IPPROTO_ICMPV6};
+use crate::{icmpv4, IPPROTO_ICMP, IPPROTO_ICMPV6, PADDING};
 
 pub fn calculate_ipv4_community_id(
     seed: u16,
@@ -24,27 +24,25 @@ pub fn calculate_ipv4_community_id(
 
     let mut is_one_way = false;
 
-    if src_port.is_some() && dst_port.is_some() {
-        let tmp_src_port = src_port.unwrap();
-        let tmp_dst_port = dst_port.unwrap();
-        match ip_proto {
-            IPPROTO_ICMP => {
-                let (src, dst, one_way) = icmpv4::get_port_equivalents(tmp_src_port, tmp_dst_port);
-                is_one_way = one_way;
-                sport = Some(src.to_be());
-                dport = Some(dst.to_be());
-            }
-            IPPROTO_ICMPV6 => return Err(anyhow!("icmpv6 can not over ipv4!")),
-            _ => {}
+    let tmp_src_port = src_port.unwrap_or_default();
+    let tmp_dst_port = dst_port.unwrap_or_default();
+    match ip_proto {
+        IPPROTO_ICMP => {
+            let (src, dst, one_way) = icmpv4::get_port_equivalents(tmp_src_port, tmp_dst_port);
+            is_one_way = one_way;
+            sport = Some(src.to_be());
+            dport = Some(dst.to_be());
         }
+        IPPROTO_ICMPV6 => return Err(anyhow!("icmpv6 can not over ipv4!")),
+        _ => {}
     }
 
-    if !(is_one_way || src_ip < dst_ip || (src_ip == dst_ip && src_port < dst_port)) {
+    if !(is_one_way || src_ip < dst_ip || (src_ip == dst_ip && sport < dport)) {
         std::mem::swap(&mut sip, &mut dip);
         std::mem::swap(&mut sport, &mut dport);
     }
 
-    let hash = if src_port.is_some() && dst_port.is_some() {
+    let hash = if sport.is_some() && dport.is_some() {
         let ipv4 = Ipv4Data {
             seed: seed.to_be(),
             src_ip: sip,

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -24,10 +24,11 @@ pub fn calculate_ipv4_community_id(
 
     let mut is_one_way = false;
 
-    let tmp_src_port = src_port.unwrap_or_default();
-    let tmp_dst_port = dst_port.unwrap_or_default();
     match ip_proto {
         IPPROTO_ICMP => {
+            let tmp_src_port = src_port.unwrap_or_default();
+            let tmp_dst_port = dst_port.unwrap_or_default();
+
             let (src, dst, one_way) = icmpv4::get_port_equivalents(tmp_src_port, tmp_dst_port);
             is_one_way = one_way;
             sport = Some(src.to_be());
@@ -181,6 +182,10 @@ mod tests {
             (
                 (0, "5.6.7.8", "1.2.3.4", None, None, 46),
                 "1:ikv3kmf89luf73WPz1jOs49S768=",
+            ),
+            (
+                (0, "100.66.124.24", "172.31.98.44", None, None, 47),
+                "1:Uo11LCySQ1S0c9jtHZVIb4Pm/2k=",
             ),
         ];
         raw.into_iter()

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -5,7 +5,7 @@ use base64::prelude::*;
 use sha1::digest::Update;
 use sha1::{Digest, Sha1};
 
-use crate::{icmpv6, PADDING, IPPROTO_ICMP,IPPROTO_ICMPV6};
+use crate::{icmpv4, icmpv6, IPPROTO_ICMP, IPPROTO_ICMPV6, PADDING};
 
 pub fn calculate_ipv6_community_id(
     seed: u16,
@@ -24,27 +24,30 @@ pub fn calculate_ipv6_community_id(
 
     let mut is_one_way = false;
 
-    if src_port.is_some() && dst_port.is_some() {
-        let tmp_src_port = src_port.unwrap();
-        let tmp_dst_port = dst_port.unwrap();
-        match ip_proto {
-            IPPROTO_ICMPV6 => {
-                let (src, dst, one_way) = icmpv6::get_port_equivalents(tmp_src_port, tmp_dst_port);
-                is_one_way = one_way;
-                sport = Some(src.to_be());
-                dport = Some(dst.to_be());
-            }
-            IPPROTO_ICMP => return Err(anyhow!("icmpv4 can not over ipv6!")),
-            _ => {}
+    let tmp_src_port = src_port.unwrap_or_default();
+    let tmp_dst_port = dst_port.unwrap_or_default();
+    match ip_proto {
+        IPPROTO_ICMP => {
+            let (src, dst, one_way) = icmpv4::get_port_equivalents(tmp_src_port, tmp_dst_port);
+            is_one_way = one_way;
+            sport = Some(src.to_be());
+            dport = Some(dst.to_be());
         }
+        IPPROTO_ICMPV6 => {
+            let (src, dst, one_way) = icmpv6::get_port_equivalents(tmp_src_port, tmp_dst_port);
+            is_one_way = one_way;
+            sport = Some(src.to_be());
+            dport = Some(dst.to_be());
+        }
+        _ => {}
     }
 
-    if !(is_one_way || src_ip < dst_ip || (src_ip == dst_ip && src_port < dst_port)) {
+    if !(is_one_way || src_ip < dst_ip || (src_ip == dst_ip && sport < dport)) {
         std::mem::swap(&mut sip, &mut dip);
         std::mem::swap(&mut sport, &mut dport);
     }
 
-    let hash = if src_port.is_some() && dst_port.is_some() {
+    let hash = if sport.is_some() && dport.is_some() {
         let ipv6 = Ipv6Data {
             seed: seed.to_be(),
             src_ip: sip,
@@ -194,6 +197,28 @@ mod tests {
                     58,
                 ),
                 "1:fYC8+pz24E+EhANP1EZhpX0Dw10=",
+            ),
+            (
+                (
+                    0,
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                    "fe00:afa0::1",
+                    Some(0),
+                    Some(8),
+                    1,
+                ),
+                "1:vW44peXVlakl8z8Pk6oaF4JDxm8=",
+            ),
+            (
+                (
+                    0,
+                    "2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6",
+                    "fe00:afa0::1",
+                    None,
+                    None,
+                    1,
+                ),
+                "1:vW44peXVlakl8z8Pk6oaF4JDxm8=",
             ),
         ];
         raw.into_iter()


### PR DESCRIPTION
This brings the implementation more inline with the Elasticsearch and reference Python implementations of community_id. Even though this is largely under-specified behavior of the spec.

Contains the changes in #4, merge afterwards. If #4 is rejected, this PR will need altering.